### PR TITLE
Dev Container development workflow

### DIFF
--- a/.devcontainer/DEVELOPING.md
+++ b/.devcontainer/DEVELOPING.md
@@ -40,6 +40,7 @@ _DevPod also provides `providers` to deploy the very same dev environment to clo
 
   - conda init
   - restart bash or start a new terminal instance
+  - `conda activate deepbiosphere`
   - `pip install -e .` to use `setup.py` to install dependencies
 
 - In order to connect to GBIF, you will need to configure `~/.netrc` with your GBIF credentials. The Docker build script will create this file with dummy credentials, but you will need to fill in your _real_ credentials.

--- a/.devcontainer/DEVELOPING.md
+++ b/.devcontainer/DEVELOPING.md
@@ -26,7 +26,7 @@ Other flags / considerations:
 
 - The @`branch` format within the git path - this allows you to clone a particular branch for development.
 
-- The flag --recreate will re-run any relevant bits in `devcontainer.json` and `dev.Dockerfile`.
+- The flag `--recreate` will re-run any relevant bits in `devcontainer.json` and `dev.Dockerfile`.
 
 - The **more extreme** flag `--reset` will re-clone the repo and re-run any relevant bits in `devcontainer.json` and `dev.Dockerfile`. **This will wipe any local changes!**
 

--- a/.devcontainer/DEVELOPING.md
+++ b/.devcontainer/DEVELOPING.md
@@ -1,0 +1,33 @@
+### Development Files
+
+1. `dev.Dockerfile` provides the Docker build environment, which pulls an image of a CUDA-enabled Ubuntu image, installs some development dependencies via `apt`, installs `conda`, and then installs python and its necessary dependencies.
+
+2. `environment.yml` which configures the conda python requirements, channels to install from, and necessary dependencies.
+
+3. `devcontainer.json` which configures where to build the docker container (as of now, `../`, which builds in the root of the repo), mounts the `.ssh` directory to allow git access, and enables some VSCode extensions within the repo. **Note that since the docker container is an isolated environment, you will not be able to use your local extensions inside the container within specifying them here.**
+
+#### VSCode Dev Container
+
+First off, ensure Docker is installed, VSCode is installed, and the `Dev Containers` extension is installed. Then, with the repo open in VSCode, run the following command using the command pallete:
+
+`Cmd + Shift + P > "Dev Containers: Reopen in Dev Container`
+
+This will build the dev container, run it, and connect to it via ssh.
+
+#### DevPod Dev Container Call
+
+DevPod takes the same `devcontainer.json` and does some extra work to prepare your development environment - as of now, this call performs the same as the above:
+
+```
+devpod up git@github.com:SchmidtDSE/deepbiosphere@main --devcontainer-path .devcontainer/devcontainer.json --debug  --ide vscode
+```
+
+Note the @`branch` format - this allows you to clone a particular branch for development.
+
+Howevever, DevPod also provides `providers` to deploy the very same dev environment to cloud infrastructure (`AWS`, `GCP`, `Azure`, etc) to more seamlessly scale up and deploy. Information will be provided here when this is vetted.
+
+#### Important Notes
+
+- In order to connect to GBIF, you will need to configure `~/.netrc` with your GBIF credentials. The Docker build script will create this file with dummy credentials, but you will need to fill in your _real_ credentials.
+
+- You will also need a .env in the _root of the repo_ that contains the same contents as `example.env`. Some of this you shouldn't have to change (mostly, the paths to relevant files inside the running container), but some is specific to you. Note that this needs to be done in addition to the above `~/.netrc` stuff.

--- a/.devcontainer/DEVELOPING.md
+++ b/.devcontainer/DEVELOPING.md
@@ -32,7 +32,7 @@ Other flags / considerations:
 
 It is recommended to `--recreate` and make sure everything still works before merging any PRs.
 
-_DevPod also provides `providers` to deploy the very same dev environment to cloud infrastructure (`AWS`, `GCP`, `Azure`, etc) to more seamlessly scale up and deploy. Information will be provided here when this is vetted._
+_DevPod also provides `providers` to deploy the very same dev environment to cloud infrastructure (`AWS`, `GCP`, `Azure`, etc) to more seamlessly scale up and deploy. Information will be provided here when this is implemented._
 
 #### Important Notes
 

--- a/.devcontainer/DEVELOPING.md
+++ b/.devcontainer/DEVELOPING.md
@@ -22,9 +22,17 @@ DevPod takes the same `devcontainer.json` and does some extra work to prepare yo
 devpod up git@github.com:SchmidtDSE/deepbiosphere@main --devcontainer-path .devcontainer/devcontainer.json --debug  --ide vscode
 ```
 
-Note the @`branch` format - this allows you to clone a particular branch for development.
+Other flags / considerations:
 
-Howevever, DevPod also provides `providers` to deploy the very same dev environment to cloud infrastructure (`AWS`, `GCP`, `Azure`, etc) to more seamlessly scale up and deploy. Information will be provided here when this is vetted.
+- The @`branch` format within the git path - this allows you to clone a particular branch for development.
+
+- The flag --recreate will re-run any relevant bits in `devcontainer.json` and `dev.Dockerfile`.
+
+- The **more extreme** flag `--reset` will re-clone the repo and re-run any relevant bits in `devcontainer.json` and `dev.Dockerfile`. **This will wipe any local changes!**
+
+It is recommended to `--recreate` and make sure everything still works before merging any PRs.
+
+_DevPod also provides `providers` to deploy the very same dev environment to cloud infrastructure (`AWS`, `GCP`, `Azure`, etc) to more seamlessly scale up and deploy. Information will be provided here when this is vetted._
 
 #### Important Notes
 

--- a/.devcontainer/DEVELOPING.md
+++ b/.devcontainer/DEVELOPING.md
@@ -36,6 +36,12 @@ _DevPod also provides `providers` to deploy the very same dev environment to clo
 
 #### Important Notes
 
+- pip and conda don't play nice - for now, you will need to excute the following after build:
+
+  - conda init
+  - restart bash or start a new terminal instance
+  - `pip install -e .` to use `setup.py` to install dependencies
+
 - In order to connect to GBIF, you will need to configure `~/.netrc` with your GBIF credentials. The Docker build script will create this file with dummy credentials, but you will need to fill in your _real_ credentials.
 
 - You will also need a .env in the _root of the repo_ that contains the same contents as `example.env`. Some of this you shouldn't have to change (mostly, the paths to relevant files inside the running container), but some is specific to you. Note that this needs to be done in addition to the above `~/.netrc` stuff.

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -57,6 +57,20 @@ RUN Rscript -e "install.packages('reticulate')"
 
 FROM base as runtime_environment
 
+# Make directories for local data storage
+RUN mkdir -p /workspace/devcontainer/data/occs
+RUN mkdir /workspaces/devcontainer/data/occs/
+RUN mkdir /workspaces/devcontainer/data/shpfiles/
+RUN mkdir /workspaces/devcontainer/data/models/
+RUN mkdir /workspaces/devcontainer/data/images/
+RUN mkdir /workspaces/devcontainer/data/rasters/
+RUN mkdir /workspaces/devcontainer/data/baselines/
+RUN mkdir /workspaces/devcontainer/data/results/
+RUN mkdir /workspaces/devcontainer/data/misc/
+RUN mkdir /workspaces/devcontainer/data/docs/
+RUN mkdir /workspaces/devcontainer/data/scratch/
+RUN mkdir /workspaces/devcontainer/data/runs/
+
 # Copy the conda environment from the environment stage
 COPY --from=dev_environment /opt/conda /opt/conda
 

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -31,10 +31,10 @@ RUN apt-get update && apt-get install -y \
 
 # Copy deepbiosphere src
 COPY . /workspace/deepbiosphere
-WORKDIR /workspace
+WORKDIR /workspace/deepbiosphere
 
 # Install conda environment
-RUN conda env create -f deepbiosphere/.devcontainer/environment.yml
+RUN conda env create -f .devcontainer/environment.yml
 
 # Install deepbiosphere package dependencies using pip
 RUN /opt/conda/bin/pip install -e .

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -57,6 +57,9 @@ RUN Rscript -e "install.packages('reticulate')"
 
 FROM base as runtime_environment
 
+# Make .netrc file for auth with GBIF
+RUN echo "machine api.gbif.org login gbif password gbif" > ~/.netrc
+
 # Make directories for local data storage
 RUN mkdir -p /workspace/devcontainer/data/occs
 RUN mkdir /workspaces/devcontainer/data/occs/

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -61,18 +61,18 @@ RUN touch ~/.netrc
 RUN echo "machine api.gbif.org login gbif password gbif" > ~/.netrc
 
 # Make directories for local data storage
-RUN mkdir -p /workspace/devcontainer/data/occs
-RUN mkdir /workspaces/devcontainer/data/occs/
-RUN mkdir /workspaces/devcontainer/data/shpfiles/
-RUN mkdir /workspaces/devcontainer/data/models/
-RUN mkdir /workspaces/devcontainer/data/images/
-RUN mkdir /workspaces/devcontainer/data/rasters/
-RUN mkdir /workspaces/devcontainer/data/baselines/
-RUN mkdir /workspaces/devcontainer/data/results/
-RUN mkdir /workspaces/devcontainer/data/misc/
-RUN mkdir /workspaces/devcontainer/data/docs/
-RUN mkdir /workspaces/devcontainer/data/scratch/
-RUN mkdir /workspaces/devcontainer/data/runs/
+RUN mkdir -p /workspace/devcontainer/data/occs \
+    && mkdir /workspaces/devcontainer/data/occs/ \
+    && mkdir /workspaces/devcontainer/data/shpfiles/ \
+    && mkdir /workspaces/devcontainer/data/models/ \
+    && mkdir /workspaces/devcontainer/data/images/ \
+    && mkdir /workspaces/devcontainer/data/rasters/ \
+    && mkdir /workspaces/devcontainer/data/baselines/ \
+    && mkdir /workspaces/devcontainer/data/results/ \
+    && mkdir /workspaces/devcontainer/data/misc/ \
+    && mkdir /workspaces/devcontainer/data/docs/ \
+    && mkdir /workspaces/devcontainer/data/scratch/ \
+    && mkdir /workspaces/devcontainer/data/runs/
 
 # Copy the conda environment from the environment stage
 COPY --from=dev_environment /opt/conda /opt/conda

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -43,7 +43,7 @@ WORKDIR /workspace/deepbiosphere
 
 # Install deepbiosphere package dependencies using pip, within the conda environment
 RUN conda env create -f .devcontainer/environment.yml
-RUN conda run -n deepbiosphere pip install -e .
+# RUN conda run -n deepbiosphere pip install -e .
 
 # Set up R environment for reticulate
 RUN Rscript -e "install.packages('reticulate')"

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -1,0 +1,44 @@
+# Use a base image with Python 3.7+ and CUDA
+FROM nvidia/cuda:12.6.2-cudnn-devel-ubuntu24.04 AS base
+
+# Install base utilities
+RUN apt-get update \
+    && apt-get install -y build-essential \
+    && apt-get install -y wget \
+    && apt-get install -y git \
+    && apt-get install -y curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install miniconda
+ENV CONDA_DIR=/opt/conda
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda
+
+# Put conda in path so we can use conda activate
+ENV PATH=$CONDA_DIR/bin:$PATH
+
+FROM base AS dev_environment
+
+# Set up environment variables for CUDA and PyTorch
+ENV TORCH_CUDA_ARCH_LIST="6.0;6.1;7.0"
+ENV IABN_FORCE_CUDA=1
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    gcc g++ r-base \
+    && apt-get clean
+
+# Install Python dependencies with conda
+COPY .devcontainer/environment.yml /workspace/environment.yml
+
+# Clone the deepbiosphere repository
+WORKDIR /workspace
+RUN conda env create -f environment.yml
+RUN git clone https://github.com/moiexpositoalonsolab/deepbiosphere.git
+
+# Set up R environment for reticulate
+RUN Rscript -e "install.packages('reticulate')"
+
+# Default command to open bash for devcontainer interaction
+CMD ["/bin/bash"]

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -54,7 +54,7 @@ RUN Rscript -e "install.packages('reticulate')"
 ### RUNTIME ENVIRONMENT ###
 ###########################
 
-FROM base as runtime_environment
+FROM base AS runtime_environment
 
 # Make .netrc file for auth with GBIF
 RUN touch ~/.netrc \

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -43,7 +43,6 @@ WORKDIR /workspace/deepbiosphere
 
 # Install deepbiosphere package dependencies using pip, within the conda environment
 RUN conda env create -f .devcontainer/environment.yml
-# RUN conda run -n deepbiosphere pip install -e .
 
 # Set up R environment for reticulate
 RUN Rscript -e "install.packages('reticulate')"

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -44,9 +44,8 @@ WORKDIR /workspace/deepbiosphere
 # Install conda environment
 RUN conda env create -f .devcontainer/environment.yml
 
-# Install deepbiosphere package dependencies using pip
-## DEBUG: doing this interactively in the container to ensure torch isn't an issue
-# RUN /opt/conda/bin/pip install -e .
+# Install deepbiosphere package dependencies using pip, within the conda environment
+RUN conda activate deepbiosphere && pip install -e .
 
 # Set up R environment for reticulate
 RUN Rscript -e "install.packages('reticulate')"

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -41,14 +41,14 @@ RUN apt-get update && apt-get install -y \
 COPY . /workspace/deepbiosphere
 WORKDIR /workspace/deepbiosphere
 
-# Install conda environment
-RUN conda env create -f .devcontainer/environment.yml \
-    && conda init
-
 # Install deepbiosphere package dependencies using pip, within the conda environment
-RUN bash -c "source ~/.bashrc \
+RUN bash -c " \
+    conda env create -f .devcontainer/environment.yml \
+    && conda init \
+    source ~/.bashrc \
     && conda activate deepbiosphere \
-    && pip install -e ."
+    && pip install -e .\
+"
 
 # Set up R environment for reticulate
 RUN Rscript -e "install.packages('reticulate')"

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -58,6 +58,7 @@ RUN Rscript -e "install.packages('reticulate')"
 FROM base as runtime_environment
 
 # Make .netrc file for auth with GBIF
+RUN touch ~/.netrc
 RUN echo "machine api.gbif.org login gbif password gbif" > ~/.netrc
 
 # Make directories for local data storage

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -61,8 +61,7 @@ RUN touch ~/.netrc \
     && echo "machine api.gbif.org login YOUR_GBIF_LOGIN password YOUR_GBIF_PASSWORD" > ~/.netrc
 
 # Make directories for local data storage
-RUN mkdir -p /workspace/devcontainer/data/occs \
-    && mkdir /workspaces/devcontainer/data/occs/ \
+RUN mkdir -p /workspaces/devcontainer/data/occs \
     && mkdir /workspaces/devcontainer/data/shpfiles/ \
     && mkdir /workspaces/devcontainer/data/models/ \
     && mkdir /workspaces/devcontainer/data/images/ \

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -42,10 +42,11 @@ COPY . /workspace/deepbiosphere
 WORKDIR /workspace/deepbiosphere
 
 # Install conda environment
-RUN conda env create -f .devcontainer/environment.yml
+RUN conda env create -f .devcontainer/environment.yml \
+    && conda init
 
 # Install deepbiosphere package dependencies using pip, within the conda environment
-RUN conda init \ 
+RUN source ~/.bashrc \ 
     && conda activate deepbiosphere \
     && pip install -e .
 

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -45,7 +45,7 @@ WORKDIR /workspace/deepbiosphere
 RUN bash -c " \
     conda env create -f .devcontainer/environment.yml \
     && conda init \
-    source ~/.bashrc \
+    && source ~/.bashrc \
     && conda activate deepbiosphere \
     && pip install -e .\
 "

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -36,6 +36,9 @@ WORKDIR /workspace
 # Install conda environment
 RUN conda env create -f deepbiosphere/.devcontainer/environment.yml
 
+# Install deepbiosphere package dependencies using pip
+RUN /opt/conda/bin/pip install -e .
+
 # Set up R environment for reticulate
 RUN Rscript -e "install.packages('reticulate')"
 

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -58,7 +58,7 @@ FROM base as runtime_environment
 
 # Make .netrc file for auth with GBIF
 RUN touch ~/.netrc \
-    && echo "machine api.gbif.org login gbif password gbif" > ~/.netrc
+    && echo "machine api.gbif.org login YOUR_GBIF_LOGIN password YOUR_GBIF_PASSWORD" > ~/.netrc
 
 # Make directories for local data storage
 RUN mkdir -p /workspace/devcontainer/data/occs \

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get update \
 
 # Install miniconda
 ENV CONDA_DIR=/opt/conda
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /opt/conda
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+    && /bin/bash ~/miniconda.sh -b -p /opt/conda
 
 # Put conda in path so we can use conda activate
 ENV PATH=$CONDA_DIR/bin:$PATH
@@ -57,8 +57,8 @@ RUN Rscript -e "install.packages('reticulate')"
 FROM base as runtime_environment
 
 # Make .netrc file for auth with GBIF
-RUN touch ~/.netrc
-RUN echo "machine api.gbif.org login gbif password gbif" > ~/.netrc
+RUN touch ~/.netrc \
+    && echo "machine api.gbif.org login gbif password gbif" > ~/.netrc
 
 # Make directories for local data storage
 RUN mkdir -p /workspace/devcontainer/data/occs \

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
 
 # Install miniconda
 ENV CONDA_DIR=/opt/conda
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh \
     && /bin/bash ~/miniconda.sh -b -p /opt/conda
 
 # Put conda in path so we can use conda activate

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -45,7 +45,9 @@ WORKDIR /workspace/deepbiosphere
 RUN conda env create -f .devcontainer/environment.yml
 
 # Install deepbiosphere package dependencies using pip, within the conda environment
-RUN conda activate deepbiosphere && pip install -e .
+RUN conda init \ 
+    && conda activate deepbiosphere \
+    && pip install -e .
 
 # Set up R environment for reticulate
 RUN Rscript -e "install.packages('reticulate')"

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -29,13 +29,12 @@ RUN apt-get update && apt-get install -y \
     gcc g++ r-base \
     && apt-get clean
 
-# Install Python dependencies with conda
-COPY .devcontainer/environment.yml /workspace/environment.yml
-
-# Clone the deepbiosphere repository
+# Copy deepbiosphere src
+COPY . /workspace/deepbiosphere
 WORKDIR /workspace
-RUN conda env create -f environment.yml
-RUN git clone https://github.com/moiexpositoalonsolab/deepbiosphere.git
+
+# Install conda environment
+RUN conda env create -f deepbiosphere/.devcontainer/environment.yml
 
 # Set up R environment for reticulate
 RUN Rscript -e "install.packages('reticulate')"

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -42,13 +42,8 @@ COPY . /workspace/deepbiosphere
 WORKDIR /workspace/deepbiosphere
 
 # Install deepbiosphere package dependencies using pip, within the conda environment
-RUN bash -c " \
-    conda env create -f .devcontainer/environment.yml \
-    && conda init \
-    && source ~/.bashrc \
-    && conda activate deepbiosphere \
-    && pip install -e .\
-"
+RUN conda env create -f .devcontainer/environment.yml
+RUN conda run -n deepbiosphere pip install -e .
 
 # Set up R environment for reticulate
 RUN Rscript -e "install.packages('reticulate')"

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -58,17 +58,17 @@ RUN touch ~/.netrc \
     && echo "machine api.gbif.org login YOUR_GBIF_LOGIN password YOUR_GBIF_PASSWORD" > ~/.netrc
 
 # Make directories for local data storage
-RUN mkdir -p /workspaces/devcontainer/data/occs \
-    && mkdir /workspaces/devcontainer/data/shpfiles/ \
-    && mkdir /workspaces/devcontainer/data/models/ \
-    && mkdir /workspaces/devcontainer/data/images/ \
-    && mkdir /workspaces/devcontainer/data/rasters/ \
-    && mkdir /workspaces/devcontainer/data/baselines/ \
-    && mkdir /workspaces/devcontainer/data/results/ \
-    && mkdir /workspaces/devcontainer/data/misc/ \
-    && mkdir /workspaces/devcontainer/data/docs/ \
-    && mkdir /workspaces/devcontainer/data/scratch/ \
-    && mkdir /workspaces/devcontainer/data/runs/
+RUN mkdir -p /workspaces/deepbiosphere/data/occs \
+    && mkdir /workspaces/deepbiosphere/data/shpfiles/ \
+    && mkdir /workspaces/deepbiosphere/data/models/ \
+    && mkdir /workspaces/deepbiosphere/data/images/ \
+    && mkdir /workspaces/deepbiosphere/data/rasters/ \
+    && mkdir /workspaces/deepbiosphere/data/baselines/ \
+    && mkdir /workspaces/deepbiosphere/data/results/ \
+    && mkdir /workspaces/deepbiosphere/data/misc/ \
+    && mkdir /workspaces/deepbiosphere/data/docs/ \
+    && mkdir /workspaces/deepbiosphere/data/scratch/ \
+    && mkdir /workspaces/deepbiosphere/data/runs/
 
 # Copy the conda environment from the environment stage
 COPY --from=dev_environment /opt/conda /opt/conda

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -46,9 +46,9 @@ RUN conda env create -f .devcontainer/environment.yml \
     && conda init
 
 # Install deepbiosphere package dependencies using pip, within the conda environment
-RUN source ~/.bashrc \ 
+RUN bash -c "source ~/.bashrc \
     && conda activate deepbiosphere \
-    && pip install -e .
+    && pip install -e ."
 
 # Set up R environment for reticulate
 RUN Rscript -e "install.packages('reticulate')"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
     "dockerfile": "dev.Dockerfile",
     "context": "../"
   },
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind" 
+  ],
   "customizations": {
     "vscode": {
       "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,7 @@
     "dockerfile": "dev.Dockerfile",
     "context": "../"
   },
-  "mounts": [
-    "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind" 
-  ],
+  "mounts": ["source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind"],
   "customizations": {
     "vscode": {
       "settings": {
@@ -20,6 +18,5 @@
     "ms-vscode.cpptools",
     "ms-vscode-remote.remote-containers"
   ],
-  "forwardPorts": [],
-  "remoteUser": "vscode"
+  "forwardPorts": []
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "deepbiosphere-devcontainer",
+  "build": {
+    "dockerfile": "dev.Dockerfile",
+    "context": "../"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      }
+    }
+  },
+  "extensions": [
+    "ms-python.python",
+    "ms-toolsai.jupyter",
+    "ms-vscode.cpptools",
+    "ms-vscode-remote.remote-containers"
+  ],
+  "forwardPorts": [],
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/environment.yml
+++ b/.devcontainer/environment.yml
@@ -2,9 +2,12 @@ name: deepbiosphere
 channels:
   - defaults
   - conda-forge
+  - nvidia
+  - pytorch
 dependencies:
   - python=3.11
-  - torch
+  - pytorch
+  - pytorch-cuda=11.8
   - torchvision
   - inplace-abn
   - rpy2

--- a/.devcontainer/environment.yml
+++ b/.devcontainer/environment.yml
@@ -1,0 +1,12 @@
+name: deepbiosphere
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pytorch
+  - torchvision
+  - inplace-abn
+  - rpy2
+  - shapely
+  - pygeos

--- a/.devcontainer/environment.yml
+++ b/.devcontainer/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.11
-  - pytorch
+  - torch
   - torchvision
   - inplace-abn
   - rpy2

--- a/.devcontainer/environment.yml
+++ b/.devcontainer/environment.yml
@@ -13,5 +13,3 @@ dependencies:
   - rpy2
   - shapely
   - pygeos
-  - pip
-    - -e .

--- a/.devcontainer/environment.yml
+++ b/.devcontainer/environment.yml
@@ -13,3 +13,5 @@ dependencies:
   - rpy2
   - shapely
   - pygeos
+  - pip
+    - -e .

--- a/.devcontainer/example.env
+++ b/.devcontainer/example.env
@@ -1,0 +1,15 @@
+GBIF_USER=your_user
+GBIF_EMAIL=your_email
+
+PATH_OCCS='/workspaces/devcontainer/data/occs/',
+PATH_SHPFILES='/workspaces/devcontainer/data/shpfiles/',
+PATH_MODELS='/workspaces/devcontainer/data/models/',
+PATH_IMAGES='/workspaces/devcontainer/data/images/',
+PATH_RASTERS='/workspaces/devcontainer/data/rasters/',
+PATH_BASELINES='/workspaces/devcontainer/data/baselines/',
+PATH_RESULTS='/workspaces/devcontainer/data/results/',
+PATH_MISC='/workspaces/devcontainer/data/misc/',
+PATH_DOCS='/workspaces/devcontainer/data/docs/',
+PATH_SCRATCH='/workspaces/devcontainer/data/scratch/',
+PATH_RUNS='/workspaces/devcontainer/data/runs/',
+PATH_BLOB_ROOT='https://naipblobs.blob.core.windows.net/'

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ dbs_memex
 scripts/
 test.py
 .Rproj.user
+
+
+# Whitelist the .devcontainer folder to follow devcontainer conventions
+!.devcontainer/

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ test.py
 
 # Whitelist the .devcontainer folder to follow devcontainer conventions
 !.devcontainer/
+
+# Whitelist vscode debugger configurations
+!.vscode/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,7 @@
       "program": "${workspaceFolder}/src/deepbiosphere/Build_Data.py",
       "args": [
         "--dset_path",
-        "/workspace/devcontainer/data/occs/data/occs/plant_2018_2019_USA_5_1_acq2024_10_25.csv",
+        "/workspaces/devcontainer/data/occs/data/occs/plant_2018_2019_USA_5_1_acq2024_10_25.csv",
         "--daset_id",
         "test_westernJOTR_small",
         "--sep",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,7 @@
       "program": "${workspaceFolder}/src/deepbiosphere/Build_Data.py",
       "args": [
         "--dset_path",
-        "/workspaces/devcontainer/data/occs/data/occs/plant_2018_2019_USA_5_1_acq2024_10_25.csv",
+        "/workspaces/devcontainer/data/occs/plant_2018_2019_USA_5_1_acq2024_10_25.csv",
         "--daset_id",
         "test_westernJOTR_small",
         "--sep",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Inference",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/src/deepbiosphere/Inference.py",
+      "args": ["--band", "-1", "--model", "rf", "--filename", "debug_test"],
+      "python": "/opt/conda/envs/deepbiosphere/bin/python",
+      "justMyCode": true,
+      "console": "integratedTerminal",
+      "envFile": "${workspaceFolder}/.env"
+    },
+    {
+      "name": "Python: Download GBIF Data",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/src/deepbiosphere/Download_GBIF_Data.py",
+      "args": [
+        "--organism",
+        "plant",
+        "--start_date",
+        "2018",
+        "--end_date",
+        "2019",
+        "--wkt_geometry",
+        "POLYGON ((-116.264191 34.1209, -116.265564 34.077687, -116.453705 34.074275, -116.457825 33.976392, -116.151581 33.840764, -115.787659 33.836201, -115.801392 34.039005, -116.004639 34.036729, -116.003265 34.073137, -116.036224 34.077687, -116.05957 34.119763, -116.264191 34.1209))"
+      ],
+      "python": "/opt/conda/envs/deepbiosphere/bin/python",
+      "justMyCode": true,
+      "console": "integratedTerminal",
+      "envFile": "${workspaceFolder}/.env"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,6 +31,34 @@
       "justMyCode": true,
       "console": "integratedTerminal",
       "envFile": "${workspaceFolder}/.env"
+    },
+    {
+      "name": "Python: Build Data",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/src/deepbiosphere/Build_Data.py",
+      "args": [
+        "--dset_path",
+        "/workspace/devcontainer/data/occs/data/occs/plant_2018_2019_USA_5_1_acq2024_10_25.csv",
+        "--daset_id",
+        "test_westernJOTR_small",
+        "--sep",
+        "\\t",
+        "--year",
+        "2012",
+        "--state",
+        "ca",
+        "--threshold",
+        "500",
+        "--idCol",
+        "gbifID",
+        "--parallel",
+        "0"
+      ],
+      "python": "/opt/conda/envs/deepbiosphere/bin/python",
+      "justMyCode": true,
+      "console": "integratedTerminal",
+      "envFile": "${workspaceFolder}/.env"
     }
   ]
 }

--- a/src/deepbiosphere/Download_GBIF_Data.py
+++ b/src/deepbiosphere/Download_GBIF_Data.py
@@ -19,7 +19,7 @@ import datetime
 def request_gbif_records(gbif_user, gbif_email, organism, start_date="2015", end_date="2022", area=['USA.5_1'], wkt_geometry=None):
 
     # confirm email roughly matches email shape
-    if not re.match(r"[^@]+@[^@]+\.[^@]+", email):
+    if not re.match(r"[^@]+@[^@]+\.[^@]+", gbif_email):
         raise ValueError("It looks like {} is not a valid email address!".format(gbif_email))
 
 

--- a/src/deepbiosphere/Download_GBIF_Data.py
+++ b/src/deepbiosphere/Download_GBIF_Data.py
@@ -212,7 +212,7 @@ def request_gbif_records(gbif_user, gbif_email, organism, start_date="2015", end
     if resp.json()['status'] == "SUCCEEDED":
         req = requests.get("https://api.gbif.org/v1/occurrence/download/{}".format(id.text))
         curr_time = datetime.datetime.now()
-        savepath = f"{paths.OCCS}{taxon}_{start_date}_{end_date}_{area[0].replace('.','_')}_acq{curr_time.year}_{curr_time.month}_{curr_time.day}"
+        savepath = f"{paths.OCCS}{organism}_{start_date}_{end_date}_{area[0].replace('.','_')}_acq{curr_time.year}_{curr_time.month}_{curr_time.day}"
         savelink = f"{savepath}.zip"
         download_url(req.json()['downloadLink'], savelink)
         print("data successfully saved to {}".format(savelink))

--- a/src/deepbiosphere/Download_GBIF_Data.py
+++ b/src/deepbiosphere/Download_GBIF_Data.py
@@ -156,7 +156,6 @@ def request_gbif_records(gbif_user, gbif_email, organism, start_date="2015", end
     else:
         area_json = {
             "type": "within",
-            "key": "GEOMETRY",
             "geometry": wkt_geometry
         }
 

--- a/src/deepbiosphere/Download_GBIF_Data.py
+++ b/src/deepbiosphere/Download_GBIF_Data.py
@@ -16,18 +16,18 @@ import datetime
 # country code from https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3  [code].[state number]_1
 # where state number is the alphabetical sorting of states
 # TODO: use GADM to resolve state / country names to their administrative area ids
-def request_gbif_records(gbif_usr, email, taxon, start_date="2015", end_date="2022", area=['USA.5_1'], wkt_geometry=None):
+def request_gbif_records(gbif_user, gbif_email, organism, start_date="2015", end_date="2022", area=['USA.5_1'], wkt_geometry=None):
 
     # confirm email roughly matches email shape
     if not re.match(r"[^@]+@[^@]+\.[^@]+", email):
-        raise ValueError("It looks like {} is not a valid email address!".format(email))
+        raise ValueError("It looks like {} is not a valid email address!".format(gbif_email))
 
 
     # create download predicate json file
     down_pred = {
-        'creator' : gbif_usr,
+        'creator' : gbif_user,
         "notificationAddresses": [
-            email
+            gbif_email
         ],
         "sendNotification": True,
         "format": "SIMPLE_CSV",
@@ -86,7 +86,7 @@ def request_gbif_records(gbif_usr, email, taxon, start_date="2015", end_date="20
 
     taxon_json = None
     # get the taxon and add it to json
-    if taxon == 'animal':
+    if organism == 'animal':
 
         taxon_json = {
                     "type": "equals",
@@ -94,21 +94,21 @@ def request_gbif_records(gbif_usr, email, taxon, start_date="2015", end_date="20
                     "value": "1",
                     "matchCase": False
                 }
-    elif taxon == 'plant':
+    elif organism == 'plant':
         taxon_json = {
                     "type": "equals",
                     "key": "TAXON_KEY",
                     "value": "6", 
                     "matchCase": False
                 }
-    elif taxon == 'bacteria':
+    elif organism == 'bacteria':
         taxon_json = {
                     "type": "equals",
                     "key": "TAXON_KEY",
                     "value": "3",
                     "matchCase": False
                 }
-    elif taxon == 'plantanimal':
+    elif organism == 'plantanimal':
         # do a group join
         taxon_json = {
             "type": "or",

--- a/src/deepbiosphere/Utils.py
+++ b/src/deepbiosphere/Utils.py
@@ -26,18 +26,18 @@ IMAGENET_CHANS = 3
 ## ---------- Paths to important directories ---------- ##
 
 paths = SimpleNamespace(
-    OCCS = '/your/path/here/',
-    SHPFILES = '/your/path/here/',
-    MODELS = '/your/path/here/',
-    IMAGES = '/your/path/here/',
-    RASTERS = '/your/path/here/',
-    BASELINES = '/your/path/here/',
-    RESULTS = '/your/path/here/',
-    MISC = '/your/path/here/',
-    DOCS = '/your/path/here/',
-    SCRATCH = '/your/path/here/',
-    RUNS = '/your/path/here/',
-    BLOB_ROOT = 'https://naipblobs.blob.core.windows.net/'
+    OCCS=os.getenv('PATH_OCCS'),
+    SHPFILES=os.getenv('PATH_SHPFILES'),
+    MODELS=os.getenv('PATH_MODELS'),
+    IMAGES=os.getenv('PATH_IMAGES'),
+    RASTERS=os.getenv('PATH_RASTERS'),
+    BASELINES=os.getenv('PATH_BASELINES'),
+    RESULTS=os.getenv('PATH_RESULTS'),
+    MISC=os.getenv('PATH_MISC'),
+    DOCS=os.getenv('PATH_DOCS'),
+    SCRATCH=os.getenv('PATH_SCRATCH'),
+    RUNS=os.getenv('PATH_RUNS'),
+    BLOB_ROOT=os.getenv('PATH_BLOB_ROOT', 'https://naipblobs.blob.core.windows.net/')
 )
 
 ## ---------- Base class for function type checking enum ---------- ##

--- a/src/deepbiosphere/Utils.py
+++ b/src/deepbiosphere/Utils.py
@@ -25,7 +25,7 @@ IMAGENET_CHANS = 3
 
 ## ---------- Paths to important directories ---------- ##
 
- paths = SimpleNamespace(
+paths = SimpleNamespace(
     OCCS = '/your/path/here/',
     SHPFILES = '/your/path/here/',
     MODELS = '/your/path/here/',
@@ -37,7 +37,8 @@ IMAGENET_CHANS = 3
     DOCS = '/your/path/here/',
     SCRATCH = '/your/path/here/',
     RUNS = '/your/path/here/',
-    BLOB_ROOT = 'https://naipblobs.blob.core.windows.net/')
+    BLOB_ROOT = 'https://naipblobs.blob.core.windows.net/'
+)
 
 ## ---------- Base class for function type checking enum ---------- ##
 


### PR DESCRIPTION
This fork is essentially attempting to run the DeepBiosphere model top to bottom, but within a Dev Container for reproducibility and ease of development's sake!

As of now, these are the only changes:

- Rather than run everything in the local env, I added most of the README getting started steps (system dependencies, python dependencies, directory structure, gbif auth) into `dev.Dockerfile`. Assuming that you have `Docker` installed locally alongside VSCode with the `Dev Containers` extension, you can run `Dev Containers: Reopen in Container` to build and run the development image and connect to it via SSH with VSCode.  Alongside this, within the `.devcontainer` folder, there are a couple other files - (1) `devcontainer.json` which essentially helps VSCode connect to that built container and provides some customization options, and (2) `environment.yml` which is a conda environment file that the `Docker` build script uses to get the proper version of Python pre-installed, along with its packages (inplace-abn, shapely, pygeos, etc).

-  I've added VSCode launch configs to `.vscode` to step thru and test `Download_GBIF_Data.py` and `Build_Data.py` (as well as `Inference.py` but I haven't tried that one yet - related to #5 ). Unfortunately the args to the CLI calls within the launch json are hardcoded, since I can't find any way to use vars in the actual launch json itself, but the structure is easily modifiable!

- To cut down on the size of my GBIF call, I added an additional flag to the CLI call for `Build_Data`, which optionally passes a WKT geometry rather than an area string. This allows me to use a very small demo area within the Mojave for dev purposes. Alongside that, I changed a couple of var names for internal consistency, but no changes to functionality there. 

- Lastly, added a local `.env` within the repo itself to hold my local paths to relevant inputs / outputs. It looks like this:
```
GBIF_USER=npg
GBIF_EMAIL=npg@berkeley.edu

PATH_OCCS='/workspaces/devcontainer/data/occs/',
PATH_SHPFILES='/workspaces/devcontainer/data/shpfiles/',
PATH_MODELS='/workspaces/devcontainer/data/models/',
PATH_IMAGES='/workspaces/devcontainer/data/images/',
PATH_RASTERS='/workspaces/devcontainer/data/rasters/',
PATH_BASELINES='/workspaces/devcontainer/data/baselines/',
PATH_RESULTS='/workspaces/devcontainer/data/results/',
PATH_MISC='/workspaces/devcontainer/data/misc/',
PATH_DOCS='/workspaces/devcontainer/data/docs/',
PATH_SCRATCH='/workspaces/devcontainer/data/scratch/',
PATH_RUNS='/workspaces/devcontainer/data/runs/',
PATH_BLOB_ROOT='https://naipblobs.blob.core.windows.net/'
```
This gets called in my fork by `Utils.py`, such that my local development doesn't cause any merge conflicts one day!

